### PR TITLE
docs/test: --verboseのドキュメント・テスト追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -66,7 +66,7 @@ diffai weights1.npy weights2.npy --epsilon 0.001
 --epsilon <N>           # 浮動小数点の許容誤差
 --ignore-keys-regex RE  # 正規表現にマッチするキーを無視
 --quiet                 # 終了コードのみ返す（0:同一, 1:差分あり）
---verbose               # 詳細分析を表示
+--verbose               # 差分なし時に確認メッセージを表示
 ```
 
 ## 出力記号

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ diffai weights1.npy weights2.npy --epsilon 0.001
 --epsilon <N>           # Float comparison tolerance
 --ignore-keys-regex RE  # Ignore keys matching regex
 --quiet                 # Return only exit code (0: same, 1: diff found)
---verbose               # Show detailed analysis
+--verbose               # Show confirmation when no differences
 ```
 
 ## Output Symbols

--- a/diffai-cli/src/input.rs
+++ b/diffai-cli/src/input.rs
@@ -39,7 +39,6 @@ pub fn infer_format_from_path(path: &Path) -> Option<Format> {
 pub fn parse_content(_content: &str, format: Format) -> Result<Value> {
     // AI/ML files are binary formats and cannot be read from stdin
     Err(anyhow::anyhow!(
-        "Format {:?} not supported for stdin input. AI/ML files are binary formats and must be read from files. diffai only supports: .pt, .pth, .safetensors, .npy, .npz, .mat",
-        format
+        "Format {format:?} not supported for stdin input. AI/ML files are binary formats and must be read from files. diffai only supports: .pt, .pth, .safetensors, .npy, .npz, .mat"
     ))
 }

--- a/diffai-cli/tests/cmd/output.md
+++ b/diffai-cli/tests/cmd/output.md
@@ -29,6 +29,49 @@ $ diffai tests/fixtures/model_v1.safetensors tests/fixtures/model_v2.safetensors
 
 ```
 
+## Verbose Mode
+
+With differences, output is unchanged.
+
+```console
+$ diffai tests/fixtures/model_v1.safetensors tests/fixtures/model_v2.safetensors --verbose
+? 1
+  ~ tensors.fc1.weight.data_summary.max: 0.09999847412109375 -> 0.1999977082014084
+  ~ tensors.fc1.weight.data_summary.mean: -7.629394644971532e-7 -> 0.049998855736234304
+  ~ tensors.fc1.weight.data_summary.min: -0.10000000149011612 -> -0.10000000894069672
+  ~ tensors.fc1.weight.data_summary.std: 0.057735027919685454 -> 0.0866025439171912
+  ~ tensors.fc2.weight.data_summary.max: 0.14999085664749146 -> 0.16998779773712158
+  ~ tensors.fc2.weight.data_summary.mean: -4.57763690064894e-6 -> -0.03000610376952295
+  ~ tensors.fc2.weight.data_summary.min: -0.15000000596046448 -> -0.23000000417232513
+  ~ tensors.fc2.weight.data_summary.std: 0.08660254389937629 -> 0.11547005545920479
+
+
+```
+
+Without differences, verbose shows confirmation message.
+
+```console
+$ diffai tests/fixtures/model_v1.safetensors tests/fixtures/model_v1.safetensors --verbose
+No differences found
+
+```
+
+## Verbose Short Form
+
+```console
+$ diffai tests/fixtures/model_v1.safetensors tests/fixtures/model_v1.safetensors -v
+No differences found
+
+```
+
+## Verbose with Brief
+
+```console
+$ diffai tests/fixtures/model_v1.safetensors tests/fixtures/model_v1.safetensors --verbose --brief
+Files tests/fixtures/model_v1.safetensors and tests/fixtures/model_v1.safetensors are identical
+
+```
+
 ## Version
 
 ```console

--- a/diffai-core/src/diff.rs
+++ b/diffai-core/src/diff.rs
@@ -38,14 +38,10 @@ pub fn diff_paths(
         (true, true) => diff_directories(path1, path2, options),
         (false, false) => diff_files(path1, path2, options),
         (true, false) => Err(anyhow!(
-            "Cannot compare directory '{}' with file '{}'",
-            old_path,
-            new_path
+            "Cannot compare directory '{old_path}' with file '{new_path}'"
         )),
         (false, true) => Err(anyhow!(
-            "Cannot compare file '{}' with directory '{}'",
-            old_path,
-            new_path
+            "Cannot compare file '{old_path}' with directory '{new_path}'"
         )),
     }
 }
@@ -205,9 +201,7 @@ fn diff_files(
     // Ensure both files have the same format
     if std::mem::discriminant(&format1) != std::mem::discriminant(&format2) {
         return Err(anyhow!(
-            "Cannot compare files with different formats: {:?} vs {:?}",
-            format1,
-            format2
+            "Cannot compare files with different formats: {format1:?} vs {format2:?}"
         ));
     }
 

--- a/diffai-core/src/parsers/mod.rs
+++ b/diffai-core/src/parsers/mod.rs
@@ -26,8 +26,7 @@ pub fn detect_format_from_path(path: &Path) -> Result<FileFormat> {
                 .and_then(|ext| ext.to_str())
                 .unwrap_or("unknown");
             Err(anyhow!(
-                "Unsupported file format: '{}'. diffai only supports AI/ML file formats: .pt, .pth, .safetensors, .npy, .npz, .mat. For general structured data formats, please use diffx.",
-                ext
+                "Unsupported file format: '{ext}'. diffai only supports AI/ML file formats: .pt, .pth, .safetensors, .npy, .npz, .mat. For general structured data formats, please use diffx."
             ))
         }
     }

--- a/diffai-core/src/types.rs
+++ b/diffai-core/src/types.rs
@@ -131,7 +131,7 @@ impl OutputFormat {
             "diffai" => Ok(Self::Diffai),
             "json" => Ok(Self::Json),
             "yaml" | "yml" => Ok(Self::Yaml),
-            _ => Err(anyhow!("Invalid output format: {}", s)),
+            _ => Err(anyhow!("Invalid output format: {s}")),
         }
     }
 }

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -128,21 +128,19 @@ diffai -q model1.pt model2.pt && echo "同じ" || echo "異なる"
 
 #### `-v, --verbose`
 
-詳細なML分析情報を表示する。
+差分がない場合に確認メッセージを表示する。
 
-**出力内容**:
+**差分なしの場合**:
 ```
-learning_rate_analysis:
-  old: 0.001
-  new: 0.0015
-  change: +50.0%
-  trend: increasing
-gradient_analysis:
-  flow_health: healthy
-  norm: 0.021
-  variance_change: +15.3%
-...
+No differences found
 ```
+
+**`--brief` と併用（差分なし）**:
+```
+Files model_v1.safetensors and model_v2.safetensors are identical
+```
+
+**差分ありの場合**: 通常出力と同じ（追加情報なし）。
 
 ---
 


### PR DESCRIPTION
## Summary
- trycmd テストに verbose 出力検証4ケース追加（差分あり/なし/短縮形/brief併用）
- cli.md の verbose セクションを実際の動作に合わせて修正
- clippy 警告修正（uninlined_format_args）

## Test plan
- [x] `cargo test --package diffai` 全テスト通過
- [x] trycmd verbose 4ケース通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)